### PR TITLE
Fix failure issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,4 +16,4 @@ jobs:
       contents: read
     uses: ./.github/workflows/reusable-deploy.yml
     with:
-      stage: ${{ matrix.stage }}​
+      stage: ${{ matrix.stage }}

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -30,6 +30,6 @@ jobs:
         run: echo '${{ inputs.stage }}'
 
       - name: debug step
-        run: yarn serverless print --stage '${STAGE}'
+        run: yarn serverless print --stage "${STAGE}"
         env:
           STAGE: ${{ inputs.stage }}

--- a/serverless.yml
+++ b/serverless.yml
@@ -7,7 +7,7 @@ package:
 provider:
   name: aws
   runtime: nodejs16.x
-  
+
 functions:
   app:
     handler: src/handler.main


### PR DESCRIPTION
- Fix quoting in shell for var i.e. use double quote instead of single ones
- Fix trailing space issues (looks like there was an invalid character for the `stage`)

Fixing both issues resolved the failure.
The CI workflow is now passing.
Please test and verify on your side.

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>